### PR TITLE
DM-36247: Update for Gafaelfawr cleanup

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -484,13 +484,14 @@ This would allow chaining Gafaelfawr instances.
 InfluxDB tokens
 ---------------
 
-Gafaelfawr contains support for minting authentication tokens for InfluxDB 1.x.
+Gafaelfawr used to contain support for minting authentication tokens for InfluxDB 1.x.
 This version of InfluxDB_ expects a JWT (using the ``HS256`` algorithm) created with a symmetric key shared between the InfluxDB server and the authentication provider.
 
 .. _InfluxDB: https://www.influxdata.com/
 
-InfluxDB 2.0 dropped this authentication mechanism, so we do not expect to continue using it indefinitely.
-It therefore isn't mentioned in the design or implementation documents.
+We never ended up using the Gafaelfawr integration, instead using username and password because it was easier to manage across deployments.
+InfluxDB 2.0 then dropped this authentication mechanism, so we removed the Gafaelfawr support.
+Hopefully, future InfluxDB releases will be able to use the OpenID Connect support.
 
 Storage
 =======

--- a/index.rst
+++ b/index.rst
@@ -599,7 +599,6 @@ The **IDM-XXXX** references are to requirements listed in SQR-044_, which may pr
 
 .. rst-class:: compact
 
-- Implement user self-groups (groups with the same name as the username)
 - Register and validate ``remote_uri`` for OpenID Connect clients, and relax the requirement that they be in the same domain
 - Use multiple domains to control JavaScript access and user cookies
 - Filter out the token from ``Authorization`` headers of incoming requests
@@ -627,7 +626,6 @@ The **IDM-XXXX** references are to requirements listed in SQR-044_, which may pr
 - Merging accounts (IDM-1311)
 - Logging of administrative actions tagged appropriately (IDM-1400, IDM-1403, IDM-1404)
 - Affiliation-based groups (IDM-2001)
-- Group name restrictions (IDM-2004)
 - Expiration of group membership (IDM-2005)
 - Group renaming while preserving GID (IDM-2006)
 - Correct handling of group deletion (IDM-2007)


### PR DESCRIPTION
- Document the history of `X-Auth-Request-*` headers
- Note that we removed InfluxDB 1.x support
- Remove some completed work items