### PR TITLE
DM-55349: Update documenteer dependency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,5 +7,6 @@ updates:
 
   - package-ecosystem: "pip"
     directory: "/"
+    versioning-strategy: "increase-if-necessary"
     schedule:
       interval: "weekly"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-documenteer[technote]>=1.0,<2.0
+documenteer[technote]>=1.0,<3.0


### PR DESCRIPTION
Allow documenteer 2.x and update the dependabot configuration so that it stops trying to increase the lower bound of the dependency.